### PR TITLE
Make stringify function less lossy and mirror JSON spec

### DIFF
--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -52,7 +52,7 @@
 
 (defn- stringify
   [thing]
-  (if (or (map? thing) (string? thing) (number? thing) (sequential? thing))
+  (if (or (map? thing) (string? thing) (number? thing) (nil? thing) (true? thing) (false? thing) (sequential? thing))
     thing
     (str thing)))
 


### PR DESCRIPTION
Current `stringify` function is more lossy than it needs to be as it will cast `nil` to `""` which can make Bugsnag data less inspectable than it needs to be.

A JSON value can be any of these:
object
array
string
number
"true"
"false"
"null"

Source: https://www.json.org/