### PR TITLE
chore: add clj-kondo config to suppress the usage of clj-bugsnag.core/notify

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -2,5 +2,6 @@
  ["marick/midje"]
 
  :linters
- {:refer-all
+ {:discouraged-var {clj-bugsnag.core/notify {:message "Please don't use this function directly as it can save PII data into bugsnag"}}
+  :refer-all
   {:exclude [midje.sweet]}}}


### PR DESCRIPTION
This PR added clj-kondo config add warning when notify function is used directly as it can store PII data into bugsnag.